### PR TITLE
Workaround for Vivado bug

### DIFF
--- a/vhdl/src/en_cl_fix_pkg.vhd
+++ b/vhdl/src/en_cl_fix_pkg.vhd
@@ -1623,7 +1623,8 @@ package body en_cl_fix_pkg is
 		
 		-- Convert to fixed-point in chunks
 		for i in 0 to ChunkCount_c-1 loop
-			Chunk_v := std_logic_vector(to_unsigned(integer(ASat_v mod 2.0**ChunkSize_c), ChunkSize_c));
+			-- Note: Due to a Xilinx Vivado bug, we must explicitly call the math_real mod operator
+			Chunk_v := std_logic_vector(to_unsigned(integer(ieee.math_real."mod"(ASat_v, 2.0**ChunkSize_c)), ChunkSize_c));
 			Result_v((i+1)*ChunkSize_c-1 downto i*ChunkSize_c) := Chunk_v;
 			ASat_v := floor(ASat_v/2.0**ChunkSize_c);
 		end loop;

--- a/vhdl/src/en_cl_fix_pkg.vhd
+++ b/vhdl/src/en_cl_fix_pkg.vhd
@@ -1860,7 +1860,7 @@ package body en_cl_fix_pkg is
 										return std_logic_vector is
 		variable line_v		: line;
 		variable ok_v		: boolean;
-		variable temp_v		: string (cl_fix_width (result_fmt)-1 downto 0);
+		variable temp_v		: string (cl_fix_width (result_fmt) downto 1);
 		variable result_v	: std_logic_vector (cl_fix_width (result_fmt)-1 downto 0);
 	begin
 		readline(a, line_v);
@@ -1882,7 +1882,7 @@ package body en_cl_fix_pkg is
 										return std_logic_vector is
 		variable line_v		: line;
 		variable ok_v		: boolean;
-		variable temp_v		: string (cl_fix_width (result_fmt)-1 downto 0);
+		variable temp_v		: string (cl_fix_width (result_fmt) downto 1);
 		variable result_v	: std_logic_vector (cl_fix_width (result_fmt)-1 downto 0);
 	begin
 		readline(a, line_v);


### PR DESCRIPTION
Due to a Vivado bug, the `mod` operator is not resolved correctly. The bug has been confirmed by Xilinx:
https://forums.xilinx.com/t5/Synthesis/Vivado-2020-1-fails-to-resolve-mod-operator/m-p/1222761

The workaround is to call the `ieee.math_real."mod"` function explicitly. This now builds successfully with Vivado 2020.1.

When Xilinx checked the code, they also noted that other parts of the code are illegal. Two strings are indexed downto 0 (which is illegal because VHDL strings have positive indices). I also fixed these definitions. There is no regression test covering these, but the change looks safe because the subsequent `cl_fix_from_hex` and `cl_fix_from_bin` function calls copy immediately into a new string with well-defined range: `a_v := a;`.