### PR TITLE
Make Python bittrue models an installable package

### DIFF
--- a/bittrue/models/python/.gitignore
+++ b/bittrue/models/python/.gitignore
@@ -1,0 +1,7 @@
+build/
+__pycache__
+*.pyc
+*.egg-info
+uv.lock
+.python-version
+

--- a/bittrue/models/python/pyproject.toml
+++ b/bittrue/models/python/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "en-cl-fix-pkg"
+version = "0.1.0"
+description = "True Bit Python models for Fixed Point HDL"
+requires-python = ">=3.10"
+dependencies = [
+    "numpy",
+]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+


### PR DESCRIPTION
Add a `pyproject.toml` file to make the package installable as a dependency.

Related to https://github.com/enclustra/en_cl_fix/issues/35

Example to install in a virtual env:

```bash
# Install
python3 -m venv .venv
.venv/bin/pip install "git+https://github.com/akukulanski/en_cl_fix.git@python-bittrue-installable#subdirectory=bittrue/models/python"

# Check
.venv/bin/python -c "import en_cl_fix_pkg; print(en_cl_fix_pkg.FixFormat(1, 3, 4))"
# (1, 3, 4)
```
